### PR TITLE
Correct data access for `thetaMode`

### DIFF
--- a/OpenPMDClasses/PMDField.C
+++ b/OpenPMDClasses/PMDField.C
@@ -1260,7 +1260,7 @@ PMDField::ComputeArrayThetaMode(void * dataSetArray,
             {
                 // Offset to llok at the right part of the array
                 // dataSetArray depending on the mode
-                offset1 = mode*offset0;
+                offset1 = 2*mode*offset0;
 
                 for(k = 0; k < this->thetaNbNodes; ++k) // Loop theta
                 {
@@ -1275,13 +1275,14 @@ PMDField::ComputeArrayThetaMode(void * dataSetArray,
                         m = l + k*offset0;
 
                         // Update of data with the real part
-                        finalDataArrayTmp[m] += dataSetArrayTmp[l + offset1]
+                        finalDataArrayTmp[m] += 
+			          dataSetArrayTmp[l + offset1 - offset0]
                                    *cos(mode*theta);
 
                         // Update of the data with the imaginary
                         // part
                         finalDataArrayTmp[m] +=
-                                   dataSetArrayTmp[l + offset1 + offset0]
+                                  dataSetArrayTmp[l + offset1]
                                   *thetaImSign*sin(mode*theta);
 
                     }

--- a/OpenPMDClasses/PMDField.C
+++ b/OpenPMDClasses/PMDField.C
@@ -1201,7 +1201,7 @@ PMDField::ComputeArrayThetaMode(void * dataSetArray,
             {
                 // Offset to llok at the right part of the array
                 // dataSetArray depending on the mode
-                offset1 = mode*offset0;
+                offset1 = 2*mode*offset0;
 
                 for(k = 0; k < this->thetaNbNodes; ++k) // Loop theta
                 {
@@ -1215,13 +1215,14 @@ PMDField::ComputeArrayThetaMode(void * dataSetArray,
                         m = l + k*offset0;
 
                         // Update of data with the real part
-                        finalDataArrayTmp[m] += dataSetArrayTmp[l + offset1]
+                        finalDataArrayTmp[m] += 
+			           dataSetArrayTmp[l + offset1 - offset0]
                                    *cos(mode*theta);
 
                         // Update of the data with the imaginary
                         // part
                         finalDataArrayTmp[m] +=
-                                   dataSetArrayTmp[l + offset1 + offset0]
+                                   dataSetArrayTmp[l + offset1]
                                   *sin(mode*theta);
 
                     }


### PR DESCRIPTION
I recently found a small typo in the code that reads `thetaMode` ; the error only shows up when having at least 3 modes (i.e. modes m=0, m=1, m=2), which is uncommon and explains why it has not been seen before.

As a reminder, in the openPMD file, the data is stored in the following order:
- Mode m=0
- Real part of mode m=1
- Imaginary part of mode m=1
- Real part of mode m=2
- Imaginary part of mode m=2

As a consequence, in the corresponding code:
- the mode m=1 should be obtained by accessing data at `offset0` (real part) and `2*offset0` (imaginary part)
- the mode m=2 should be obtained by accessing data at `3*offset0` (real part) and `4*offset0` (imaginary part)

However, with the current `master` branch, the mode m=2 is obtained by accessing data at `2*offset` and `3*offset`. This PR corrects the issue.

Note that I also tested this by looking at realistic simulation data.