### PR TITLE
Updated the Mac OSX installation instructions

### DIFF
--- a/OpenPMDClasses/PMDField.C
+++ b/OpenPMDClasses/PMDField.C
@@ -524,11 +524,11 @@ PMDField::SetGeometry(char * name,
         err = H5Aread(attrId, attrType, buffer);
         buffer[size] = '\0';
 
-        if (strstr(buffer,"cartesian")>0)
+        if (strstr(buffer,"cartesian"))
         {
             geometry = "cartesian";
         }
-        else if (strstr(buffer,"thetaMode")>0)
+        else if (strstr(buffer,"thetaMode"))
         {
             geometry = "thetaMode";
         }

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -5,33 +5,28 @@ Installation instructions for Ubuntu
 
 First, download and install the MacOs executable (.dmg image)
 [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/executables).
+(Please note that we recommend version 2.11: this has been used successfully with this plugin
+on High Sierra.)
 
-On MacOs, you can choose to install the plugin only for you or all users.
-For this aim, we will first use the xml2cmake tool located in `<Visit application directory>/Contents/Resources/bin/`.
-We recommend to add an alias in your `~/.profile`.
-
-To install the plugin for you only:
-
+After downloading/cloning the plugin source, we will use the `xml2cmake` tool located in
 ```
-xml2cmake OpenPMD.xml
+<Visit application directory>/Contents/Resources/bin/
 ```
+where `<Visit application directory>`
+would usually be `/Applications/VisIt.app`. You can either use this directly, or add an alias
+in your `~/.profile`.
 
-In this case, the compiled library will be generated in the directory `~/.visit/`.
-
-To install the plugin for all users:
+To generate the `CMakeLists.txt`, run: 
 
 ```
 xml2cmake -public -clobber OpenPMD.xml
 ```
 
-In this case, the plugin will be located where you have installed VisIt.
-If you used the .dmg image, you will find the files in:
-
-```
-/Applications/VisIt.app/Contents/Resources/<VisIt version>/darwin-x86_64/plugins/databases/
-```
-
+Note that you may need to prepend a path to a Python 2 interpreter for this step.
 This step generates the file `CMakeLists.txt` in the source directory.
+
+If your system uses cmake version >= 3 (you can check using `cmake --version`) then it is
+necessary to add `SET(CMAKE_MACOSX_RPATH 1)` to the head of `CMakeLists.txt`.
 
 Then, prepare the makefile by doing
 
@@ -39,18 +34,23 @@ Then, prepare the makefile by doing
 cmake -DCMAKE_BUILD_TYPE:STRING=Debug
 ```
 
-This step generates the files `CMakeFiles`, `CMakeCache.txt` and `cmake_install.cmake`.
+This step generates the files `CMakeFiles/`, `CMakeCache.txt`, and `cmake_install.cmake`.
 
-To compile and generates the library:
+To compile and generate the library, use:
 
 ```
 make
 ```
 
-You have almost finished, make sure that the libraries are well generated in
-their corresponding directories. You should be able to find the files
-`libEOpenPMDDatabase_ser.dylib`, `libMOpenPMDDatabase.dylib`,
- `libEOpenPMDDatabase_par.dylib`.
+with the optional flag `-j N` with `N` the number of threads to use to speed up compilation.
+
+You have almost finished, make sure that the libraries have been successfully created in the
+plugins directory, usually
+```
+/Applications/VisIt.app/Contents/Resources/<VisIt version>/darwin-x86_64/plugins/databases/
+```
+You should be able to find the files: `libEOpenPMDDatabase_ser.dylib`, `libMOpenPMDDatabase.dylib`,
+and `libEOpenPMDDatabase_par.dylib`.
 
 ## Using Visit with openPMD
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I have updated the installation instructions for Mac OSX based on my experience installing the plugin on MacOS High Sierra. I had to use VisIt version 2.11, and after running xml2cmake I had to add `SET(CMAKE_MACOSX_RPATH 1)` to the `CMakeLists.txt` file.

I also had to remove `(pointer)>0` comparisons from `OpenPMDClasses/PMDField.C` which prevented compilation.

Finally, I wasn't sure which branch to use for this PR. The `CONTRIBUTING.md` file says `dev`, but there is no `dev` branch, and the `develop` branch hasn't been updated as recently as `master`. Perhaps this can be updated/clarified in the documentation.